### PR TITLE
Adding debug for rip_redistribute_add

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1594,8 +1594,10 @@ void rip_redistribute_add(struct rip *rip, int type, int sub_type,
 
 	if (IS_RIP_DEBUG_EVENT)
        	{
-
-		 zlog_debug("Redistribute new prefix %pFX version_send %d version_recvice %d  socket %d table %pFX neighbor %pI4,distance %d,default-metric %d update_time %u timeout-time %u garbage-time %u",p,rip->version_send,rip->version_recv,rip->sock,rip->table,rip->neighbor,rip->distance,rip->default_metric,rip->update_time,rip->timeout_time,rip->garbage_time);
+		 zlog_debug("Redistribute new prefix %pFX,version_send%d,version_recvice%d,socket%d, table%pFX,neighbor%pI4,distance%d,default-metric%dupdate_time%u,timeout-time%u,garbage-time %u",
+				 p,rip->version_send,rip->version_recv,rip->sock,rip->table,
+				 rip->neighbor,rip->distance,rip->default_metric,
+				 rip->update_time,rip->timeout_time,rip->garbage_time);
 	}
 
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1594,8 +1594,8 @@ void rip_redistribute_add(struct rip *rip, int type, int sub_type,
 
 	if (IS_RIP_DEBUG_EVENT)
        	{
-		 zlog_debug("Redistribute new prefix %pFX,version_send%d,version_recvice%d,socket%d, table%pFX,neighbor%pI4,distance%d,default-metric%dupdate_time%u,timeout-time%u,garbage-time %u",
-				 p,rip->version_send,rip->version_recv,rip->sock,rip->table,
+		 zlog_debug("Redistribute new prefix %pFX,version_send %d,version_receive %d,socket %d,trigger %d,neighbor%pI4,distance%d,default-metric %d,update_time %u,timeout-time %u,garbage-time %u",
+				 p,rip->version_send,rip->version_recv,rip->sock,rip->trigger,
 				 rip->neighbor,rip->distance,rip->default_metric,
 				 rip->update_time,rip->timeout_time,rip->garbage_time);
 	}

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1592,9 +1592,12 @@ void rip_redistribute_add(struct rip *rip, int type, int sub_type,
 	} else
 		(void)rip_ecmp_add(rip, &newinfo);
 
-	if (IS_RIP_DEBUG_EVENT) {
-		zlog_debug("Redistribute new prefix %pFX", p);
+	if (IS_RIP_DEBUG_EVENT)
+       	{
+
+		 zlog_debug("Redistribute new prefix %pFX version_send %d version_recvice %d  socket %d table %pFX neighbor %pI4,distance %d,default-metric %d update_time %u timeout-time %u garbage-time %u",p,rip->version_send,rip->version_recv,rip->sock,rip->table,rip->neighbor,rip->distance,rip->default_metric,rip->update_time,rip->timeout_time,rip->garbage_time);
 	}
+
 
 	rip_event(rip, RIP_TRIGGERED_UPDATE, 0);
 }


### PR DESCRIPTION
Issue Number #21

RCA: NULL

FIX: Added debug log to print the rip data structure  

UT Case:

Router enabled with all debug commands
Router configured with RIP topology
Code added to print RIP data structure 


**UT logs: Before**
Redistribute new prefix 172.32.0.0/24
 Redistribute new prefix 172.31.0.0/20

**UT logs: After**
2021/12/20 12:50:50 RIP: [HM8FP-RA379] Redistribute new prefix 30.0.0.0/24 version_send 2 version_recvice 3  socket 17 table UNK prefix neighbor 16.85.92.243,distance 0,default-metric 1 update_time 30 timeout-time 180 garbage-time 120
2021/12/20 12:50:50 RIP: [HM8FP-RA379] Redistribute new prefix 172.31.0.0/20 version_send 2 version_recvice 3  socket 17 table UNK prefix neighbor 16.85.92.243,distance 0,default-metric 1 update_time 30 timeout-time 180 garbage-time 120
2021/12/20 12:50:50 RIP: [HM8FP-RA379] Redistribute new prefix 172.32.2.0/24 version_send 2 version_recvice 3  socket 17 table UNK prefix neighbor 16.85.92.243,distance 0,default-metric 1 update_time 30 timeout-time 180 garbage-time 120
