### PR TITLE
final commit

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1780,9 +1780,11 @@ static int rip_read(struct thread *t)
 
 	/* RIP packet received */
 	if (IS_RIP_DEBUG_EVENT)
-		zlog_debug("RECV packet from %pI4 port %d on %s (VRF %s)",
+		zlog_debug("RECV packet from %pI4 port %d on %s (VRF %s)Command : %d, Version : %d, AFI : %d, Metric : %d ",
 			   &from.sin_addr, ntohs(from.sin_port),
-			   ifp ? ifp->name : "unknown", rip->vrf_name);
+			   ifp ? ifp->name : "unknown", rip->vrf_name,
+			   rip_buf.rip_packet.command,rip_buf.rip_packet.version,
+			   rip_buf.rip_packet.rte->family, rip_buf.rip_packet.rte->metric);
 
 	/* If this packet come from unknown interface, ignore it. */
 	if (ifp == NULL) {

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1594,10 +1594,7 @@ void rip_redistribute_add(struct rip *rip, int type, int sub_type,
 
 	if (IS_RIP_DEBUG_EVENT)
        	{
-		 zlog_debug("Redistribute new prefix %pFX,version_send %d,version_receive %d,socket %d,trigger %d,neighbor%pI4,distance%d,default-metric %d,update_time %u,timeout-time %u,garbage-time %u",
-				 p,rip->version_send,rip->version_recv,rip->sock,rip->trigger,
-				 rip->neighbor,rip->distance,rip->default_metric,
-				 rip->update_time,rip->timeout_time,rip->garbage_time);
+		 zlog_debug("Redistribute new prefix %pFX", p);
 	}
 
 


### PR DESCRIPTION
#20 Debug added in RIP rip_read

Logs:
2021/12/28 04:35:46 RIP: [YHSFV-ACF80] RECV packet from 20.0.0.2 port 520 on gre2 (VRF default)Command : 2, Version : 2, AFI : 512, Metric : 33554432
2021/12/28 04:35:46 RIP: [G4HZH-53B3V] RECV RESPONSE version 2 packet size 44
2021/12/28 04:35:46 RIP: [XHCQJ-PBD83]   0.0.0.0/0 -> 0.0.0.0 family 2 tag 0 metric 2
2021/12/28 04:35:46 RIP: [XHCQJ-PBD83]   30.0.0.0/24 -> 0.0.0.0 family 2 tag 0 metric 1